### PR TITLE
Use separate env vars to set annotation title and context

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,19 @@ When run on Buildkite with the `"buildkite"` profile enabled, this will also out
 
 <img width="577" alt="Buildkite build showing a SimpleCov report in a Buildkite annotation" src="https://user-images.githubusercontent.com/282113/42116587-c2e9731e-7bac-11e8-9d2f-50fa7f071f09.png">
 
-You can customize the title and annotation context, in case you have multiple coverage reports:
+You can customize the title and annotation context using environment variables in your Pipeline. You can provide multiple coverage reports for a single build by providing distinct values for the annotation context.
 
 ```yaml
 steps:
 - command: bin/rails engine1:spec
   env:
-    SIMPLECOV_BUILDKITE_CONTEXT: "Engine 1 Coverage"
+    SIMPLECOV_BUILDKITE_TITLE: "Engine 1 Coverage"
+    SIMPLECOV_BUILDKITE_CONTEXT: "engine-1-coverage"
 
 - command: bin/rails engine2:spec
   env:
-    SIMPLECOV_BUILDKITE_CONTEXT: "Engine 2 Coverage"
+    SIMPLECOV_BUILDKITE_TITLE: "Engine 2 Coverage"
+    SIMPLECOV_BUILDKITE_CONTEXT: "engine-2-coverage"
 ```
 
   [Rails]: https://rubyonrails.org

--- a/lib/simplecov/buildkite/annotation_formatter.rb
+++ b/lib/simplecov/buildkite/annotation_formatter.rb
@@ -55,7 +55,7 @@ module SimpleCov::Buildkite
       if ENV['BUILDKITE']
         system 'buildkite-agent',
                'annotate',
-               '--context', ENV.fetch("SIMPLECOV_BUILDKITE_CONTEXT", "simplecov").gsub(/\s/,'').downcase,
+               '--context', annotation_context,
                '--style', 'info',
                message
       else
@@ -67,6 +67,10 @@ module SimpleCov::Buildkite
 
     def annotation_title
       ENV.fetch("SIMPLECOV_BUILDKITE_TITLE", "Coverage")
+    end
+
+    def annotation_context
+      ENV.fetch("SIMPLECOV_BUILDKITE_CONTEXT", "simplecov")
     end
 
     def ignore_empty_groups(groups)

--- a/lib/simplecov/buildkite/annotation_formatter.rb
+++ b/lib/simplecov/buildkite/annotation_formatter.rb
@@ -7,7 +7,7 @@ module SimpleCov::Buildkite
                                      .values_at(:git, :general)
 
       message = <<~MESSAGE
-        #### #{ENV.fetch("SIMPLECOV_BUILDKITE_CONTEXT", "Coverage")}
+        #### #{annotation_title}
 
         <dl class="flex flex-wrap m1 mxn2">
       MESSAGE
@@ -64,6 +64,10 @@ module SimpleCov::Buildkite
     end
 
     private
+
+    def annotation_title
+      ENV.fetch("SIMPLECOV_BUILDKITE_TITLE", "Coverage")
+    end
 
     def ignore_empty_groups(groups)
       groups.select do |_name, group|

--- a/lib/simplecov/buildkite/annotation_formatter.rb
+++ b/lib/simplecov/buildkite/annotation_formatter.rb
@@ -1,3 +1,5 @@
+require "shellwords"
+
 module SimpleCov::Buildkite
   class AnnotationFormatter
     GIT_ANNOTATION_FORMAT_REGEX = /^Files (?<action>changed|added) in (?<changeset>[a-zA-Z0-9.]+)$/
@@ -70,7 +72,7 @@ module SimpleCov::Buildkite
     end
 
     def annotation_context
-      ENV.fetch("SIMPLECOV_BUILDKITE_CONTEXT", "simplecov")
+      Shellwords.shellescape(ENV.fetch("SIMPLECOV_BUILDKITE_CONTEXT", "simplecov"))
     end
 
     def ignore_empty_groups(groups)

--- a/lib/simplecov/buildkite/annotation_formatter.rb
+++ b/lib/simplecov/buildkite/annotation_formatter.rb
@@ -98,7 +98,7 @@ module SimpleCov::Buildkite
 
       metric += <<~METRIC_VALUE
 
-        **<span class="h2 regular">#{format_float(element.covered_percent)}</span>%**  
+        **<span class="h2 regular">#{format_float(element.covered_percent)}</span>%**
         #{format_line_count(element)}
 
       METRIC_VALUE

--- a/spec/simplecov/buildkite/annotation_formatter_spec.rb
+++ b/spec/simplecov/buildkite/annotation_formatter_spec.rb
@@ -24,12 +24,12 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
   end
 
   describe "output" do
-    context 'outside of buildkite' do
+    context "outside of buildkite" do
       before do
         ENV.delete("BUILDKITE")
       end
 
-      it 'emits a nicely formatted annotation to STDOUT' do
+      it "emits a nicely formatted annotation to STDOUT" do
         expect { formatter.format(result) }.to output(<<~MESSAGE).to_stdout
           #### Coverage
 
@@ -45,13 +45,13 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
       end
     end
 
-    context 'inside Buildkite' do
+    context "inside Buildkite" do
       before do
         ENV["BUILDKITE"] = "true"
       end
 
-      it 'submits a nicely formatted annotation to the Agent' do
-        expect(formatter).to receive(:system).with('buildkite-agent', 'annotate', '--context', 'simplecov', '--style', 'info', <<~MESSAGE)
+      it "submits a nicely formatted annotation to the Agent" do
+        expect(formatter).to receive(:system).with("buildkite-agent", "annotate", "--context", "simplecov", "--style", "info", <<~MESSAGE)
           #### Coverage
 
           <dl class="flex flex-wrap m1 mxn2">

--- a/spec/simplecov/buildkite/annotation_formatter_spec.rb
+++ b/spec/simplecov/buildkite/annotation_formatter_spec.rb
@@ -92,6 +92,12 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
         formatter.format(result)
       end
 
+      it "escapes the input for shell usage" do
+        ENV["SIMPLECOV_BUILDKITE_CONTEXT"] = %(Jane's Coverage: Engines / "A")
+
+        expected_context = 'Jane\\\'s\ Coverage:\ Engines\ /\ \"A\"'
+        expect(formatter).to receive(:system).with("buildkite-agent", "annotate", "--context", expected_context, any_args)
+
         formatter.format(result)
       end
     end

--- a/spec/simplecov/buildkite/annotation_formatter_spec.rb
+++ b/spec/simplecov/buildkite/annotation_formatter_spec.rb
@@ -77,5 +77,23 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
         expect { formatter.format(result) }.to output(/#### Ruby Coverage/).to_stdout
       end
     end
+
+    describe "SIMPLECOV_BUILDKITE_CONTEXT" do
+      before do
+        ENV["BUILDKITE"] = "true"
+      end
+
+      it "sets the --context flag for the buildkite-agent CLI" do
+        ENV["SIMPLECOV_BUILDKITE_CONTEXT"] = "engine-1-coverage"
+
+        expected_context = "engine-1-coverage"
+        expect(formatter).to receive(:system).with("buildkite-agent", "annotate", "--context", expected_context, any_args)
+
+        formatter.format(result)
+      end
+
+        formatter.format(result)
+      end
+    end
   end
 end

--- a/spec/simplecov/buildkite/annotation_formatter_spec.rb
+++ b/spec/simplecov/buildkite/annotation_formatter_spec.rb
@@ -68,4 +68,14 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
       end
     end
   end
+
+  describe "customizing via env vars" do
+    describe "SIMPLECOV_BUILDKITE_TITLE" do
+      it "sets the title" do
+        ENV["SIMPLECOV_BUILDKITE_TITLE"] = "Ruby Coverage"
+
+        expect { formatter.format(result) }.to output(/#### Ruby Coverage/).to_stdout
+      end
+    end
+  end
 end


### PR DESCRIPTION
Building upon #18, introduce two separate env vars for setting the annotation title and context:

- `SIMPLECOV_BUILDKITE_TITLE`
- `SIMPLECOV_BUILDKITE_CONTEXT`

The `SIMPLECOV_BUILDKITE_CONTEXT` is ideally a machine-friendly value, like `a-string-in-slug-format`. However, we also shell escape it to make sure that other values can also be accepted and used.

This also introduces tests for these env vars.

This PR, while fairly small, can also be reviewed commit-by-commit to see the changes clearly.